### PR TITLE
[ovirt] collect `engine-config -d` when available

### DIFF
--- a/sos/plugins/ovirt.py
+++ b/sos/plugins/ovirt.py
@@ -83,6 +83,8 @@ class Ovirt(Plugin, RedHatPlugin):
 
         # Copy all engine tunables and domain information
         self.add_cmd_output("engine-config --all")
+        # ... and a clearer diff from factory defaults (only on ovirt>=4.2.8)
+        self.add_cmd_output("engine-config -d")
 
         # 3.x line uses engine-manage-domains, 4.x uses ovirt-aaa-jdbc-tool
         manage_domains = 'engine-manage-domains'


### PR DESCRIPTION
Newer versions of ovirt-engine can produce a short and readable diff
from the "factory defaults".

Signed-off-by: Dan Kenigsberg <danken@redhat.com>

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [X] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [X] Is the subject and message clear and concise?
- [X] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [X] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
